### PR TITLE
Version 1.0.3.0-release

### DIFF
--- a/BAE.version
+++ b/BAE.version
@@ -13,7 +13,7 @@
 	{
 		"MAJOR" : 1,
 		"MINOR" : 0,
-		"PATCH" : 2,
+		"PATCH" : 3,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/BAE/BAE-Old.version
+++ b/GameData/BAE/BAE-Old.version
@@ -5,7 +5,7 @@
 	"VERSION": {
 		"MAJOR": 1,
 		"MINOR": 0,
-		"PATCH": 1
+		"PATCH": 3
 	},
 	"KSP_VERSION_MIN": {
 		"MAJOR": 1,

--- a/GameData/BAE/BAE.version
+++ b/GameData/BAE/BAE.version
@@ -13,7 +13,7 @@
 	{
 		"MAJOR" : 1,
 		"MINOR" : 0,
-		"PATCH" : 2,
+		"PATCH" : 3,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :

--- a/GameData/BAE/Parts/Engines/B2/BAEengine7mB2.cfg
+++ b/GameData/BAE/Parts/Engines/B2/BAEengine7mB2.cfg
@@ -128,7 +128,7 @@ MODULE
 	ignitionThreshold = 0.1
 	minThrust = 0
 	maxThrust = 16000
-	heatProduction = 1300
+	heatProduction = 650
 	fxOffset = 0, 0, 0.25
         engineAccelerationSpeed = 0.1
     	engineDecelerationSpeed = 0.2

--- a/GameData/BAE/Parts/Engines/B5/BAEengine10mB5.cfg
+++ b/GameData/BAE/Parts/Engines/B5/BAEengine10mB5.cfg
@@ -128,7 +128,7 @@ MODULE
 	ignitionThreshold = 0.1
 	minThrust = 0
 	maxThrust = 40000
-	heatProduction = 2500
+	heatProduction = 650
 	fxOffset = 0, 0, 0.25
 	engineAccelerationSpeed = 0.1
 	engineDecelerationSpeed = 0.2

--- a/GameData/BAE/changelog.md
+++ b/GameData/BAE/changelog.md
@@ -203,6 +203,10 @@
 ## Version 1.0.3.0-release
 
 * Fixed engine overheat problem.
+  * [BAEengine7mB2.cfg]
+    * [heatProduction] was 1300, now 650
+  * [BAEengine10mB5.cfg]
+    * [heatProduction] was 2500, now 650
 
 ### Status
 

--- a/GameData/BAE/readme.txt
+++ b/GameData/BAE/readme.txt
@@ -23,3 +23,15 @@ This parts pack is shared under the CC BY-NC-SA license: http://creativecommons.
 Disclaimer:
 -----------
 Behemoth Aerospace Engineering is in no way affiliated with BAE Systems plc.
+
+Change Log:
+-----------
+v1.0.3
+± Fixed engine overheat problem.
+v1.0.2
+± Tweaked engine ISP curves to reflect more realistic payload capabilities.
+v1.0.1
+± Converted all textures to DDE, so they will load faster.
+± Corrected location of version file, so it will actually work.
+v1.0.0
+Release!

--- a/changelog.md
+++ b/changelog.md
@@ -203,6 +203,10 @@
 ## Version 1.0.3.0-release
 
 * Fixed engine overheat problem.
+  * [BAEengine7mB2.cfg]
+    * [heatProduction] was 1300, now 650
+  * [BAEengine10mB5.cfg]
+    * [heatProduction] was 2500, now 650
 
 ### Status
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -203,6 +203,10 @@
 ## Version 1.0.3.0-release
 
 * Fixed engine overheat problem.
+  * [BAEengine7mB2.cfg]
+    * [heatProduction] was 1300, now 650
+  * [BAEengine10mB5.cfg]
+    * [heatProduction] was 2500, now 650
 
 ### Status
 

--- a/json/mod.json
+++ b/json/mod.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "Behemoth Aerospace Engineering",
  "labelColor": "BADA55",
- "message": "1.0.2.0",
+ "message": "1.0.3.0",
  "color": "darkgreen",
  "style": "plastic"
 }


### PR DESCRIPTION
## Version 1.0.3.0-release

* Fixed engine overheat problem.
  * [BAEengine7mB2.cfg]
    * [heatProduction] was 1300, now 650
  * [BAEengine10mB5.cfg]
    * [heatProduction] was 2500, now 650

### Status

* Issues
  * closes #28 - 1.0.3.0-release
  * updates #19 - Previous Releases Archival Upload

---